### PR TITLE
Update ingress to v1

### DIFF
--- a/helm/etl/templates/ingresses.yaml
+++ b/helm/etl/templates/ingresses.yaml
@@ -1,5 +1,5 @@
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -10,8 +10,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
+        pathType: ImplementationSpecific
+        path: /
   {{ end }}
 ---
 {{ end }}


### PR DESCRIPTION
## Summary
- update ETL chart ingress template to use `networking.k8s.io/v1`

## Testing
- `helm` was not available so no tests were run